### PR TITLE
improve test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/prisma_tests?schema=public"
+DATABASE_URL=postgresql://prisma:prisma@127.0.0.1:5432/tests

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ nvm use # if you are using nvm, otherwise use your node version
 docker compose up -d # to start the local database
 npm i
 cp .env.example .env # (no need to update DATABASE_URL if you are fine using the one from docker compose)
+npx prisma db push
 npm run test
 # The test is running for 100 iterations for each mode and validates their results.
 # Output

--- a/README.md
+++ b/README.md
@@ -9,15 +9,16 @@ For the length update operation we use prisma nested write ops and for the read 
 1. Raw -> a query with relations is written as raw SQL
 2. Nested -> a prisma with nested read queries
 3. Nested-with-transaction -> a prisma with nested read queries wrapped in a transaction (RepeatableRead to make sure read ops are constistent).
-4. Nested-with-transaction -> a prisma with nested read queries wrapped in an interactive transaction (RepeatableRead to make sure read ops are constistent).
+4. Nested-with-interactive-transaction -> a prisma with nested read queries wrapped in an _interactive_ transaction (RepeatableRead to make sure read ops are constistent).
 5. Indipendent -> different prisma queries wrapped in a transaction (RepeatableRead to make sure read ops are consistent).
 
 ## Run
 
 ```bash
 nvm use # if you are using nvm, otherwise use your node version
+docker compose up -d # to start the local database
 npm i
-cp .env.example .env # and make sure you update your DATABASE_URL based on your local setup
+cp .env.example .env # (no need to update DATABASE_URL if you are fine using the one from docker compose)
 npm run test
 # The test is running for 100 iterations for each mode and validates their results.
 # Output

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+
+name: prisma-prisma
+
+# For connection urls to the following instances, see
+# https://github.com/prisma/prisma/blob/main/TESTING.md#environment-variables
+services:
+  postgres:
+    image: postgres:10
+    restart: unless-stopped
+    # Uncomment the following line to enable query logging
+    # Then restart the container.
+    # command: ['postgres', '-c', 'log_statement=all']
+    environment:
+      - POSTGRES_DB=tests
+      - POSTGRES_USER=prisma
+      - POSTGRES_PASSWORD=prisma
+    ports:
+      - '5432:5432'
+    healthcheck:
+      test: ['CMD', 'pg_isready']
+      interval: 5s
+      timeout: 2s
+      retries: 20

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@prisma/client": "^5.3.1"
+        "@prisma/client": "^5.4.1"
       },
       "devDependencies": {
         "@types/node": "^20.8.0",
-        "prisma": "^5.3.1",
+        "prisma": "^5.4.1",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
       }
@@ -56,12 +56,12 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.3.1.tgz",
-      "integrity": "sha512-ArOKjHwdFZIe1cGU56oIfy7wRuTn0FfZjGuU/AjgEBOQh+4rDkB6nF+AGHP8KaVpkBIiHGPQh3IpwQ3xDMdO0Q==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.4.1.tgz",
+      "integrity": "sha512-xyD0DJ3gRNfLbPsC+YfMBBuLJtZKQfy1OD2qU/PZg+HKrr7SO+09174LMeTlWP0YF2wca9LxtVd4HnAiB5ketQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "5.3.1-2.61e140623197a131c2a6189271ffee05a7aa9a59"
+        "@prisma/engines-version": "5.4.1-1.2f302df92bd8945e20ad4595a73def5b96afa54f"
       },
       "engines": {
         "node": ">=16.13"
@@ -76,16 +76,16 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.3.1.tgz",
-      "integrity": "sha512-6QkILNyfeeN67BNEPEtkgh3Xo2tm6D7V+UhrkBbRHqKw9CTaz/vvTP/ROwYSP/3JT2MtIutZm/EnhxUiuOPVDA==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.4.1.tgz",
+      "integrity": "sha512-vJTdY4la/5V3N7SFvWRmSMUh4mIQnyb/MNoDjzVbh9iLmEC+uEykj/1GPviVsorvfz7DbYSQC4RiwmlEpTEvGA==",
       "devOptional": true,
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
-      "version": "5.3.1-2.61e140623197a131c2a6189271ffee05a7aa9a59",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.3.1-2.61e140623197a131c2a6189271ffee05a7aa9a59.tgz",
-      "integrity": "sha512-y5qbUi3ql2Xg7XraqcXEdMHh0MocBfnBzDn5GbV1xk23S3Mq8MGs+VjacTNiBh3dtEdUERCrUUG7Z3QaJ+h79w=="
+      "version": "5.4.1-1.2f302df92bd8945e20ad4595a73def5b96afa54f",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.4.1-1.2f302df92bd8945e20ad4595a73def5b96afa54f.tgz",
+      "integrity": "sha512-+nUQM/y8C+1GG5Ioeqcu6itFslCfxvQSAUVSMC9XM2G2Fcq0F4Afnp6m0pXF6X6iUBWen7jZBPmM9Qlq4Nr3/A=="
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
@@ -166,13 +166,13 @@
       "dev": true
     },
     "node_modules/prisma": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.3.1.tgz",
-      "integrity": "sha512-Wp2msQIlMPHe+5k5Od6xnsI/WNG7UJGgFUJgqv/ygc7kOECZapcSz/iU4NIEzISs3H1W9sFLjAPbg/gOqqtB7A==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.4.1.tgz",
+      "integrity": "sha512-op9PmU8Bcw5dNAas82wBYTG0yHnpq9/O3bhxbDBrNzwZTwBqsVCxxYRLf6wHNh9HVaDGhgjjHlu1+BcW8qdnBg==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "5.3.1"
+        "@prisma/engines": "5.4.1"
       },
       "bin": {
         "prisma": "build/index.js"

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
   "license": "ISC",
   "devDependencies": {
     "@types/node": "^20.8.0",
-    "prisma": "^5.3.1",
+    "prisma": "^5.4.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@prisma/client": "^5.3.1"
+    "@prisma/client": "^5.4.1"
   }
 }


### PR DESCRIPTION
Fixes some problems I noticed:
- Missing `break` in `switch` block led to different variants of read to be run for `nested-with-interactive-transaction` case
- Added await and explicit isolationLevel for `nested-with-interactive-transaction` as well - just to make sure
- `Promise.all` keeps running all promises even while returning with the rejected, which means that writes continue in the next "test case" which can lead to undefined and unexpected behavior. `Promise.allSettled` runs all of them, but requires different handling for the rejected one.


Also:
- Add docker-compose for quicker local testing
- Update Prisma just for good measure